### PR TITLE
110 files copied to where the daemon is startedrestarted

### DIFF
--- a/aiida_gromacs/calculations/editconf.py
+++ b/aiida_gromacs/calculations/editconf.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx editconf' executable.
 """
+import os 
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
@@ -37,6 +39,8 @@ class EditconfCalculation(CalcJob):
         spec.input('metadata.options.output_filename', valid_type=str, default='editconf.out')
         spec.input('grofile', valid_type=SinglefileData, help='Input structure file.')
         spec.input('parameters', valid_type=EditconfParameters, help='Command line parameters for gmx editconf.')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         # Optional inputs.
         spec.input('n_file', required=False, valid_type=SinglefileData, help='Index file.')

--- a/aiida_gromacs/calculations/genericMD.py
+++ b/aiida_gromacs/calculations/genericMD.py
@@ -2,9 +2,12 @@
 Generic calculation used to track input and output files of a 
 generic command.
 """
+import os
+
 from aiida.common import datastructures
 from aiida.engine import CalcJob
 from aiida.orm import List, SinglefileData, Str
+
 
 
 class GenericCalculation(CalcJob):
@@ -48,8 +51,9 @@ class GenericCalculation(CalcJob):
         # define the schema for metadata.options
         spec.input('metadata.options.output_filename', valid_type=str,
                 default='file.out', help='name of file produced by default.')
-        spec.input('metadata.options.output_dir', valid_type=str,
-                help='The directory where output files will be saved '
+        spec.input('metadata.options.output_dir', valid_type=str, 
+                default=os.getcwd(),
+                help='Directory where output files will be saved '
                     'when parsed.')
 
         # set the computational resources used for this calculation.

--- a/aiida_gromacs/calculations/genion.py
+++ b/aiida_gromacs/calculations/genion.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx genion' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
@@ -38,6 +40,8 @@ class GenionCalculation(CalcJob):
         spec.input('tprfile', valid_type=SinglefileData, help='Input tpr file.')
         spec.input('topfile', valid_type=SinglefileData, help='Input topology file.')
         spec.input('parameters', valid_type=GenionParameters, help='Command line parameters for gmx genion')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         # Optional inputs.
         spec.input('n_file', required=False, valid_type=SinglefileData, help='Index file.')

--- a/aiida_gromacs/calculations/grompp.py
+++ b/aiida_gromacs/calculations/grompp.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx grompp' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData, FolderData
@@ -39,6 +41,8 @@ class GromppCalculation(CalcJob):
         spec.input('grofile', valid_type=SinglefileData, help='Input structure')
         spec.input('topfile', valid_type=SinglefileData, help='Input topology')
         spec.input('parameters', valid_type=GromppParameters, help='Command line parameters for gmx grompp')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         # Optional inputs.
         spec.input_namespace('itp_files', valid_type=SinglefileData, required=False, dynamic=True, help='Restraint files')

--- a/aiida_gromacs/calculations/make_ndx.py
+++ b/aiida_gromacs/calculations/make_ndx.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx make_ndx' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
@@ -48,6 +50,8 @@ class Make_ndxCalculation(CalcJob):
         spec.input('grofile', valid_type=SinglefileData, required=False, help='Structure file: gro g96 pdb brk ent esp tpr')
         spec.input('instructions_file', valid_type=SinglefileData, required=False, help='Instructions for generating index file')
         spec.input('metadata.options.stdin_filename', valid_type=str, help='name of file used in stdin.')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         # Optional inputs.
         spec.input('n_file', valid_type=SinglefileData, required=False, help='Index file')

--- a/aiida_gromacs/calculations/mdrun.py
+++ b/aiida_gromacs/calculations/mdrun.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx mdrun' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData, Dict
@@ -40,6 +42,8 @@ class MdrunCalculation(CalcJob):
         spec.input('metadata.options.output_filename', valid_type=str, default='mdrun.out')
         spec.input('tprfile', valid_type=SinglefileData, help='Input structure.')
         spec.input('parameters', valid_type=MdrunParameters, help='Command line parameters for gmx mdrun')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         # Optional inputs.
         spec.input('cpi_file', valid_type=SinglefileData, required=False, help='Checkpoint file')

--- a/aiida_gromacs/calculations/pdb2gmx.py
+++ b/aiida_gromacs/calculations/pdb2gmx.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx pdb2gmx' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
@@ -37,7 +39,7 @@ class Pdb2gmxCalculation(CalcJob):
         spec.input('metadata.options.output_filename', valid_type=str, default='pdb2gmx.out')
         spec.input('pdbfile', valid_type=SinglefileData, help='Input structure.')
         spec.input('parameters', valid_type=Pdb2gmxParameters, help='Command line parameters for gmx pdb2gmx')
-        spec.input('metadata.options.output_dir', valid_type=str,
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
                 help='Directory where output files will be saved when parsed.')
 
         # Default outputs.

--- a/aiida_gromacs/calculations/pdb2gmx.py
+++ b/aiida_gromacs/calculations/pdb2gmx.py
@@ -37,6 +37,8 @@ class Pdb2gmxCalculation(CalcJob):
         spec.input('metadata.options.output_filename', valid_type=str, default='pdb2gmx.out')
         spec.input('pdbfile', valid_type=SinglefileData, help='Input structure.')
         spec.input('parameters', valid_type=Pdb2gmxParameters, help='Command line parameters for gmx pdb2gmx')
+        spec.input('metadata.options.output_dir', valid_type=str,
+                help='Directory where output files will be saved when parsed.')
 
         # Default outputs.
         spec.output('stdout', valid_type=SinglefileData, help='stdout')

--- a/aiida_gromacs/calculations/solvate.py
+++ b/aiida_gromacs/calculations/solvate.py
@@ -3,6 +3,8 @@ Calculations provided by aiida_gromacs.
 
 This calculation configures the ability to use the 'gmx solvate' executable.
 """
+import os
+
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
@@ -36,6 +38,8 @@ class SolvateCalculation(CalcJob):
         spec.input('grofile', valid_type=SinglefileData, help='Input structure')
         spec.input('topfile', valid_type=SinglefileData, help='Input topology')
         spec.input('parameters', valid_type=SolvateParameters, help='Command line parameters for gmx solvate.')
+        spec.input('metadata.options.output_dir', valid_type=str, default=os.getcwd(),
+                help='Directory where output files will be saved when parsed.')
 
         spec.output('stdout', valid_type=SinglefileData, help='stdout')
         spec.output('grofile', valid_type=SinglefileData, help='Output solvated gro file.')

--- a/aiida_gromacs/cli/genericMD.py
+++ b/aiida_gromacs/cli/genericMD.py
@@ -7,7 +7,6 @@ is set up in AiiDA
 """
 
 import os
-from pathlib import Path
 import click
 
 from aiida import cmdline, engine, orm, load_profile
@@ -18,7 +17,6 @@ from aiida_gromacs import helpers
 from aiida_gromacs.utils import searchprevious
 
 # set base path for input files.
-INPUT_DIR = os.path.join(os.getcwd())
 profile = load_profile()
 computer = helpers.get_computer()
 code = helpers.get_code(entry_point="gromacs", computer=computer)
@@ -32,14 +30,12 @@ def launch_genericMD(options):
     command = options["command"]
     inputs = options["inputs"]
     outputs = options["outputs"]
-    output_dir = options["output_dir"]
     submit = options["submit"]
 
     print(f"command: {command}")
 
     if not code:
         raise exceptions.NonExistent("Code has not been set.")
-    Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     # MyAppCalculation = CalculationFactory("gromacs.genericMD")
 
@@ -58,7 +54,7 @@ def launch_genericMD(options):
     # file names and values that are SinglefileData.
     input_files = {}
     for filename in list(inputs):
-        file_path = os.path.join(INPUT_DIR, filename)
+        file_path = os.path.join(os.getcwd(), filename)
         stripped_input = filename.split("/")[-1]
         input_files[searchprevious.format_link_label(stripped_input)] = \
             orm.SinglefileData(file=file_path)
@@ -77,7 +73,7 @@ def launch_genericMD(options):
             "description": "Run CLI job and save input and output file provenance.",
             "options": {
                 "output_filename": "file.out",
-                "output_dir": output_dir,
+                #"output_dir": os.getcwd(),
                 "parser_name": "gromacs.genericMD",
             },
         },
@@ -87,7 +83,7 @@ def launch_genericMD(options):
     # as inputs for new process if file names match
     if qb.count() > 0:
         process_inputs = searchprevious.append_prev_nodes(qb, inputs, 
-                        process_inputs, INPUT_DIR)
+                        process_inputs, os.getcwd())
 
     # check if a pytest test is running, if so run rather than submit aiida job
     # Submit your calculation to the aiida daemon
@@ -125,12 +121,6 @@ def launch_genericMD(options):
 @click.option(
     "--outputs", multiple=True, type=str, 
     help="Output file name used in the command."
-)
-@click.option(
-    "--output_dir",
-    default=os.path.join(os.getcwd()),
-    type=str,
-    help="Absolute path of directory where files are saved.",
 )
 @click.option(
     "--submit", 

--- a/aiida_gromacs/cli/genericMD.py
+++ b/aiida_gromacs/cli/genericMD.py
@@ -7,6 +7,7 @@ is set up in AiiDA
 """
 
 import os
+from pathlib import Path
 import click
 
 from aiida import cmdline, engine, orm, load_profile
@@ -17,6 +18,7 @@ from aiida_gromacs import helpers
 from aiida_gromacs.utils import searchprevious
 
 # set base path for input files.
+INPUT_DIR = os.path.join(os.getcwd())
 profile = load_profile()
 computer = helpers.get_computer()
 code = helpers.get_code(entry_point="gromacs", computer=computer)
@@ -30,12 +32,14 @@ def launch_genericMD(options):
     command = options["command"]
     inputs = options["inputs"]
     outputs = options["outputs"]
+    output_dir = options["output_dir"]
     submit = options["submit"]
 
     print(f"command: {command}")
 
     if not code:
         raise exceptions.NonExistent("Code has not been set.")
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     # MyAppCalculation = CalculationFactory("gromacs.genericMD")
 
@@ -54,7 +58,7 @@ def launch_genericMD(options):
     # file names and values that are SinglefileData.
     input_files = {}
     for filename in list(inputs):
-        file_path = os.path.join(os.getcwd(), filename)
+        file_path = os.path.join(INPUT_DIR, filename)
         stripped_input = filename.split("/")[-1]
         input_files[searchprevious.format_link_label(stripped_input)] = \
             orm.SinglefileData(file=file_path)
@@ -73,7 +77,7 @@ def launch_genericMD(options):
             "description": "Run CLI job and save input and output file provenance.",
             "options": {
                 "output_filename": "file.out",
-                #"output_dir": os.getcwd(),
+                "output_dir": output_dir,
                 "parser_name": "gromacs.genericMD",
             },
         },
@@ -83,7 +87,7 @@ def launch_genericMD(options):
     # as inputs for new process if file names match
     if qb.count() > 0:
         process_inputs = searchprevious.append_prev_nodes(qb, inputs, 
-                        process_inputs, os.getcwd())
+                        process_inputs, INPUT_DIR)
 
     # check if a pytest test is running, if so run rather than submit aiida job
     # Submit your calculation to the aiida daemon
@@ -121,6 +125,12 @@ def launch_genericMD(options):
 @click.option(
     "--outputs", multiple=True, type=str, 
     help="Output file name used in the command."
+)
+@click.option(
+    "--output_dir",
+    default=os.path.join(os.getcwd()),
+    type=str,
+    help="Absolute path of directory where files are saved.",
 )
 @click.option(
     "--submit", 

--- a/aiida_gromacs/cli/pdb2gmx.py
+++ b/aiida_gromacs/cli/pdb2gmx.py
@@ -27,6 +27,9 @@ def launch(params):
     inputs = {
         "metadata": {
             "description": params.pop("description"),
+            "options": {
+                "output_dir": os.getcwd(),
+            },
         },
     }
 

--- a/aiida_gromacs/cli/pdb2gmx.py
+++ b/aiida_gromacs/cli/pdb2gmx.py
@@ -27,9 +27,6 @@ def launch(params):
     inputs = {
         "metadata": {
             "description": params.pop("description"),
-            "options": {
-                "output_dir": os.getcwd(),
-            },
         },
     }
 

--- a/aiida_gromacs/parsers/editconf.py
+++ b/aiida_gromacs/parsers/editconf.py
@@ -37,6 +37,8 @@ class EditconfParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         # Map output files to how they are named.
         outputs = ["stdout"]
         output_template = {
@@ -70,6 +72,6 @@ class EditconfParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/parsers/genericMD.py
+++ b/aiida_gromacs/parsers/genericMD.py
@@ -13,6 +13,8 @@ from aiida.orm import SinglefileData
 from aiida.parsers.parser import Parser
 from aiida.plugins import CalculationFactory
 
+from aiida_gromacs.utils import fileparsers
+
 # entry point string under which the parser class is registered:
 GenericCalculation = CalculationFactory("gromacs.genericMD")
 
@@ -84,10 +86,7 @@ class GenericParser(Parser):
                 output_node = SinglefileData(file=handle, filename=thing)
             self.out(self.format_link_label(thing), output_node)
 
-
-        # If not in testing mode, then copy back the files.
-        if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(output_dir)
+        fileparsers.parse_process_files(self, files_retrieved, output_dir)
 
         return ExitCode(0)
     
@@ -112,4 +111,3 @@ class GenericParser(Parser):
         link_label = re.sub("_[_]+", "_", alphanumeric)
 
         return link_label
-

--- a/aiida_gromacs/parsers/genericMD.py
+++ b/aiida_gromacs/parsers/genericMD.py
@@ -84,78 +84,13 @@ class GenericParser(Parser):
                 output_node = SinglefileData(file=handle, filename=thing)
             self.out(self.format_link_label(thing), output_node)
 
-        # parse retrieved files and write them to where command was run
-        for thing in files_retrieved:
-            self.logger.info(f"Parsing '{thing}'")
-            file_path = os.path.join(output_dir, thing)
-            # file_path3 = os.path.join(output_dir, f'{thing}-test2.txt')
-            try:
-                with self.retrieved.open(thing, "rb") as handle:
-                    with open(file_path, "wb") as f_out:
-                        while True:
-                            chunk = handle.read(1024)
-                            if not chunk:
-                                break
-                            f_out.write(chunk)
 
-                # not used yet.
-                # test below for parsing log file and saving output as dict
-                '''if re.search('.log$', thing):
-                    start_string = 'Input Parameters:' #'A ?V ?E ?R ?A ?G ?E ?S'
-                    end_string = 'compressibility' #'M ?E ?G ?A ?- ?F ?L ?O ?P ?S'
-                    with self.retrieved.open(thing, "r") as file:
-                        file_content = file.read()
-                        pattern = rf"{start_string}(.*?){end_string}"
-                        matches = re.findall(pattern, file_content, re.DOTALL)
-                    file_path3 = os.path.join(output_dir, f'{thing}-matched.txt')
-                    # matched_text = self._parse_gromacs_top(thing)
-                    with open(file_path3, "w") as f_out:
-                        f_out.write('matched text:')
-                        for match in matches:
-                            lines = match.splitlines()
-                            for line in lines:
-                                f_out.write(f'{line}\n')
-                    with open(file_path3, "rb") as f_out:
-                        # output_node = SinglefileData(file=f_out, filename=f'{thing}-matched.txt')
-                        # output_node = Dict(file={"test": "test"}, filename='dict.txt')
-                        output_node = Dict({"test": "test"})
-                        output_node.label = 'test-dict'
-                    self.out(self.format_link_label('test-dict'), output_node)'''
-
-            except UnicodeDecodeError:
-                with self.retrieved.open(thing, "r") as handle:
-                    with open(file_path, "w", encoding="utf-8") as f_out:
-                        for line in handle.read():
-                            f_out.write(line)
+        # If not in testing mode, then copy back the files.
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)
     
-    def _parse_gromacs_top(self, file_path):
-        """Not used yet, test for parsing the gromacs tpr file.
-        :param file_path: The path and name of gtomacs .log file
-        :returns: The required text from the parsed file
-        """
-
-        def _find_text_between_strings(file_path, start_string, end_string):
-            with self.retrieved.open(file_path, "r") as file:
-                file_content = file.read()
-            # use re.escape to escape special characters in the strings
-            # pattern = rf"{re.escape(start_string)}(.*?){re.escape(end_string)}"
-            pattern = rf"{start_string}(.*?){end_string}"
-            # use re.DOTALL to make the dot character match newline characters as well
-            matches = re.findall(pattern, file_content, re.DOTALL)
-            return matches
-
-        #file_path = '1AKI_production.log'
-        start_string = 'A ?V ?E ?R ?A ?G ?E ?S'
-        end_string = 'M ?E ?G ?A ?- ?F ?L ?O ?P ?S'
-        # start_string = '<======  ###############  ==>\n\t<====  A V E R A G E S  ====>\n\t<==  ###############  ======>\n\n' #'A V E R A G E S'
-        # end_string = 'M E G A - F L O P S   A C C O U N T I N G'
-        matched_text = _find_text_between_strings(file_path, start_string, end_string)
-        return matched_text
-    
-
-
     @staticmethod
     def format_link_label(filename: str) -> str:
         """

--- a/aiida_gromacs/parsers/genion.py
+++ b/aiida_gromacs/parsers/genion.py
@@ -37,6 +37,8 @@ class GenionParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         outputs = ["stdout", "grofile", "topfile"]
 
         # Check that folder content is as expected
@@ -63,6 +65,6 @@ class GenionParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/parsers/grompp.py
+++ b/aiida_gromacs/parsers/grompp.py
@@ -37,6 +37,8 @@ class GromppParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         # Map output files to how they are named.
         outputs = ["stdout"]
         output_template = {
@@ -72,6 +74,6 @@ class GromppParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/parsers/make_ndx.py
+++ b/aiida_gromacs/parsers/make_ndx.py
@@ -37,6 +37,8 @@ class Make_ndxParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         # Map output files to how they are named.
         outputs = ["stdout"]
         output_template = {
@@ -69,6 +71,6 @@ class Make_ndxParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/parsers/pdb2gmx.py
+++ b/aiida_gromacs/parsers/pdb2gmx.py
@@ -37,6 +37,8 @@ class Pdb2gmxParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         # Map output files to how they are named.
         outputs = ["stdout"]
         output_template = {
@@ -74,6 +76,6 @@ class Pdb2gmxParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/parsers/solvate.py
+++ b/aiida_gromacs/parsers/solvate.py
@@ -37,6 +37,8 @@ class SolvateParser(Parser):
 
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
+        # the directory for storing parsed output files
+        output_dir = self.node.get_option("output_dir")
         outputs = ["stdout", "grofile", "topfile"]
 
         # Check that folder content is as expected
@@ -63,6 +65,6 @@ class SolvateParser(Parser):
 
         # If not in testing mode, then copy back the files.
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            self.retrieved.copy_tree(os.getcwd())
+            self.retrieved.copy_tree(output_dir)
 
         return ExitCode(0)

--- a/aiida_gromacs/utils/fileparsers.py
+++ b/aiida_gromacs/utils/fileparsers.py
@@ -4,6 +4,36 @@ Functions for parsing various gromacs input/output files and extracting
 metadata into a dictionary.
 """
 import re
+import os
+
+def parse_process_files(self, files_retrieved, output_dir):
+    """
+    Parse the retrieved files from an aiida process and save them in the
+    directory from which the process command was run
+
+    :param self: parser instance
+    :param files_retrieved: list of files retrieved from process
+    :param output_dir: path of directory where parsed files shoud be saved
+    """
+    # parse retrieved files and write them to where command was run
+    for thing in files_retrieved:
+        self.logger.info(f"Parsing '{thing}'")
+        file_path = os.path.join(output_dir, thing)
+        try:
+            with self.retrieved.open(thing, "rb") as handle:
+                with open(file_path, "wb") as f_out:
+                    while True:
+                        chunk = handle.read(1024)
+                        if not chunk:
+                            break
+                        f_out.write(chunk)
+
+        except UnicodeDecodeError:
+            with self.retrieved.open(thing, "r") as handle:
+                with open(file_path, "w", encoding="utf-8") as f_out:
+                    for line in handle.read():
+                        f_out.write(line)
+
 
 def extract_nested_dict(i, j, lines, input_dict, split_with, leading_space, 
             leading_space_check_list):


### PR DESCRIPTION
The target absolute path for copy_tree in parsers are set in the calculation rather than in the parser.